### PR TITLE
Add repo url to package.json to improve npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
         "britherscript"
     ],
     "author": "George Cook",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/georgejecook/roku-log-bsc-plugin.git"
+    },
     "license": "ISC",
     "watch": {
         "test": {


### PR DESCRIPTION
It's nice to have the repo url on npm. Here's bsc:
![image](https://user-images.githubusercontent.com/2544493/155849038-6b16d4fc-4699-4392-9235-a2b2449f7d71.png)

And here's yours (notice the missing repo url?)
![image](https://user-images.githubusercontent.com/2544493/155849049-fe045e9d-8021-4d7c-96de-9b5b95ee8e87.png)
