### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Getting started
-
-[![build](https://img.shields.io/github/workflow/status/georgejecook/roku-log-bsc-plugin/build.svg?logo=github)](https://github.com/georgejecook/roku-log-bsc-plugin/actions?query=workflow%3Abuild)
+[![build](https://img.shields.io/github/actions/workflow/status/georgejecook/roku-log-bsc-plugin/build.yml?branch=master)](https://github.com/georgejecook/roku-log-bsc-plugin/actions/workflows/build.yml)
 [![GitHub](https://img.shields.io/github/release/georgejecook/roku-log-bsc-plugin.svg?style=flat-square)](https://github.com/georgejecook/roku-log-bsc-plugin/releases)
 [![NPM Version](https://badge.fury.io/js/roku-log-bsc-plugin.svg?style=flat)](https://npmjs.org/package/roku-log-bsc-plugin)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Getting started
+
 [![build](https://img.shields.io/github/actions/workflow/status/georgejecook/roku-log-bsc-plugin/build.yml?branch=master)](https://github.com/georgejecook/roku-log-bsc-plugin/actions/workflows/build.yml)
 [![GitHub](https://img.shields.io/github/release/georgejecook/roku-log-bsc-plugin.svg?style=flat-square)](https://github.com/georgejecook/roku-log-bsc-plugin/releases)
 [![NPM Version](https://badge.fury.io/js/roku-log-bsc-plugin.svg?style=flat)](https://npmjs.org/package/roku-log-bsc-plugin)
@@ -7,7 +8,7 @@
 - In your projects `bsconfig.json` add `plugins: ["roku-log-bsc-plugin"]`
 - Add a section to bsconfig.json, as follows:
 
-```
+```json
   "rokuLog": {
     "strip": false,
     "insertPkgPath": true,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Getting started
 
-[![build](https://img.shields.io/github/actions/workflow/status/georgejecook/roku-log-bsc-plugin/build.yml?branch=master)](https://github.com/georgejecook/roku-log-bsc-plugin/actions/workflows/build.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/georgejecook/roku-log-bsc-plugin/build.yml?logo=github&branch=master)](https://github.com/georgejecook/roku-log-bsc-plugin/actions/workflows/build.yml)
 [![GitHub](https://img.shields.io/github/release/georgejecook/roku-log-bsc-plugin.svg?style=flat-square)](https://github.com/georgejecook/roku-log-bsc-plugin/releases)
 [![NPM Version](https://badge.fury.io/js/roku-log-bsc-plugin.svg?style=flat)](https://npmjs.org/package/roku-log-bsc-plugin)
 


### PR DESCRIPTION
## Changes
- Fixes build badge - see [here ](https://github.com/badges/shields/issues/8671) for more information
- Fixes build badge link - now takes you to the `build.yml` workflow results as intended
- Fix markdown formatting (linting errors from vscode extension)